### PR TITLE
Speed up Meilisearch loading by running concurrently

### DIFF
--- a/nanapi/tasks/meilisearch.py
+++ b/nanapi/tasks/meilisearch.py
@@ -71,10 +71,11 @@ async def feed_meili_collections():
 
 
 async def main():
-    await feed_meili_medias()
-    await feed_meili_charas()
-    await feed_meili_staffs()
-    await feed_meili_collections()
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(feed_meili_medias())
+        tg.create_task(feed_meili_charas())
+        tg.create_task(feed_meili_staffs())
+        tg.create_task(feed_meili_collections())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Loading the Meilisearch data concurrently rather than one run at a time should make things a little quicker. Since none of the tasks are waiting for Meilisearch to complete it probably won't make a huge difference, but still should be at least a little faster.