### PR TITLE
[wip] add waiventure db definitions

### DIFF
--- a/dbschema/migrations/00049-m1m66kk.edgeql
+++ b/dbschema/migrations/00049-m1m66kk.edgeql
@@ -1,0 +1,11 @@
+CREATE MIGRATION m1m66kk5nognqxp7hwt4w2on7qnfuclv7u2zdj7rstidlntw7a23kq
+    ONTO m1fjqfwzmxszvkdaqxd3ygmk75xhfd35kmfkr4xmgswlkh7xxoddaq
+{
+  CREATE SCALAR TYPE waicolle::WaifuStatus EXTENDING enum<WAICOLLE, WAIVENTURE, DEAD, RETIRED>;
+  ALTER TYPE waicolle::Waifu {
+      CREATE PROPERTY season: std::str;
+      CREATE PROPERTY status: waicolle::WaifuStatus {
+          SET default := (waicolle::WaifuStatus.WAICOLLE);
+      };
+  };
+};

--- a/dbschema/waicolle.esdl
+++ b/dbschema/waicolle.esdl
@@ -35,6 +35,7 @@ module waicolle {
   }
 
   scalar type CollagePosition extending enum<DEFAULT, LEFT_OF, RIGHT_OF>;
+  scalar type WaifuStatus extending enum<WAICOLLE, WAIVENTURE, DEAD, RETIRED>;
 
   type Waifu extending default::ClientObject {
     required property timestamp -> datetime {
@@ -76,6 +77,10 @@ module waicolle {
       on target delete allow;
     }
     multi link ascended_to := .<ascended_from[is Waifu];
+    property status -> WaifuStatus {
+        default := WaifuStatus.WAICOLLE;
+    }
+    property season -> str;
     property disabled := exists .ascended_to;
     property frozen := exists .owner.frozen_at;
     property trade_locked := exists (

--- a/nanapi/database/waicolle/trade_insert.py
+++ b/nanapi/database/waicolle/trade_insert.py
@@ -78,6 +78,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class TradeInsertResultReceivedOwnerUser(BaseModel):
     discord_id: str
 
@@ -118,6 +125,8 @@ class TradeInsertResultReceived(BaseModel):
     nanaed: bool
     original_owner: TradeInsertResultReceivedOriginalOwner | None
     owner: TradeInsertResultReceivedOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 
@@ -170,6 +179,8 @@ class TradeInsertResultOffered(BaseModel):
     nanaed: bool
     original_owner: TradeInsertResultOfferedOriginalOwner | None
     owner: TradeInsertResultOfferedOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/trade_select.py
+++ b/nanapi/database/waicolle/trade_select.py
@@ -62,6 +62,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class TradeSelectResultReceivedOwnerUser(BaseModel):
     discord_id: str
 
@@ -102,6 +109,8 @@ class TradeSelectResultReceived(BaseModel):
     nanaed: bool
     original_owner: TradeSelectResultReceivedOriginalOwner | None
     owner: TradeSelectResultReceivedOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 
@@ -154,6 +163,8 @@ class TradeSelectResultOffered(BaseModel):
     nanaed: bool
     original_owner: TradeSelectResultOfferedOriginalOwner | None
     owner: TradeSelectResultOfferedOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_ascendable.py
+++ b/nanapi/database/waicolle/waifu_ascendable.py
@@ -57,6 +57,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuAscendableResultKey(BaseModel):
     chara_id_al: int
     level: int
@@ -102,6 +109,8 @@ class WaifuAscendableResultElements(BaseModel):
     nanaed: bool
     original_owner: WaifuAscendableResultElementsOriginalOwner | None
     owner: WaifuAscendableResultElementsOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_bulk_update.py
+++ b/nanapi/database/waicolle/waifu_bulk_update.py
@@ -52,6 +52,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuBulkUpdateResultOwnerUser(BaseModel):
     discord_id: str
 
@@ -92,6 +99,8 @@ class WaifuBulkUpdateResult(BaseModel):
     nanaed: bool
     original_owner: WaifuBulkUpdateResultOriginalOwner | None
     owner: WaifuBulkUpdateResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_change_owner.py
+++ b/nanapi/database/waicolle/waifu_change_owner.py
@@ -48,6 +48,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuChangeOwnerResultOwnerUser(BaseModel):
     discord_id: str
 
@@ -88,6 +95,8 @@ class WaifuChangeOwnerResult(BaseModel):
     nanaed: bool
     original_owner: WaifuChangeOwnerResultOriginalOwner | None
     owner: WaifuChangeOwnerResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_edged.py
+++ b/nanapi/database/waicolle/waifu_edged.py
@@ -57,6 +57,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuEdgedResultKey(BaseModel):
     chara_id_al: int
 
@@ -101,6 +108,8 @@ class WaifuEdgedResultElements(BaseModel):
     nanaed: bool
     original_owner: WaifuEdgedResultElementsOriginalOwner | None
     owner: WaifuEdgedResultElementsOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_insert.py
+++ b/nanapi/database/waicolle/waifu_insert.py
@@ -48,6 +48,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuInsertResultOwnerUser(BaseModel):
     discord_id: str
 
@@ -88,6 +95,8 @@ class WaifuInsertResult(BaseModel):
     nanaed: bool
     original_owner: WaifuInsertResultOriginalOwner | None
     owner: WaifuInsertResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_select.py
+++ b/nanapi/database/waicolle/waifu_select.py
@@ -35,6 +35,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuSelectResultOwnerUser(BaseModel):
     discord_id: str
 
@@ -75,6 +82,8 @@ class WaifuSelectResult(BaseModel):
     nanaed: bool
     original_owner: WaifuSelectResultOriginalOwner | None
     owner: WaifuSelectResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_select_by_chara.py
+++ b/nanapi/database/waicolle/waifu_select_by_chara.py
@@ -38,6 +38,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuSelectByCharaResultOwnerUser(BaseModel):
     discord_id: str
 
@@ -78,6 +85,8 @@ class WaifuSelectByCharaResult(BaseModel):
     nanaed: bool
     original_owner: WaifuSelectByCharaResultOriginalOwner | None
     owner: WaifuSelectByCharaResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/database/waicolle/waifu_select_by_user.edgeql
+++ b/nanapi/database/waicolle/waifu_select_by_user.edgeql
@@ -11,6 +11,7 @@ with
   as_og := <optional bool>$as_og ?? false,
   disabled := <optional bool>$disabled ?? false,
   exclude_custom_image := <optional bool>$exclude_custom_image ?? false,
+  status := <waicolle::WaifuStatus>$status,
   player := (select waicolle::Player filter .client = global client and .user.discord_id = discord_id),
 select waicolle::Waifu {
   *,
@@ -37,6 +38,7 @@ and (.trade_locked = trade_locked if exists trade_locked else true)
 and (.blooded = blooded if exists blooded else true)
 and (.nanaed = nanaed if exists nanaed else true)
 and (.custom_collage = custom_collage if exists custom_collage else true)
+and (.status = status if exists status else true)
 and (.level > 0 if exists ascended else true)
 and .disabled = disabled
 order by .timestamp desc

--- a/nanapi/database/waicolle/waifu_select_by_user.py
+++ b/nanapi/database/waicolle/waifu_select_by_user.py
@@ -2,6 +2,7 @@
 # pyright: strict
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 from uuid import UUID
 
 from gel import AsyncIOExecutor
@@ -21,6 +22,7 @@ with
   as_og := <optional bool>$as_og ?? false,
   disabled := <optional bool>$disabled ?? false,
   exclude_custom_image := <optional bool>$exclude_custom_image ?? false,
+  status := <waicolle::WaifuStatus>$status,
   player := (select waicolle::Player filter .client = global client and .user.discord_id = discord_id),
 select waicolle::Waifu {
   *,
@@ -47,16 +49,32 @@ and (.trade_locked = trade_locked if exists trade_locked else true)
 and (.blooded = blooded if exists blooded else true)
 and (.nanaed = nanaed if exists nanaed else true)
 and (.custom_collage = custom_collage if exists custom_collage else true)
+and (.status = status if exists status else true)
 and (.level > 0 if exists ascended else true)
 and .disabled = disabled
 order by .timestamp desc
 """
 
 
+WAIFU_SELECT_BY_USER_STATUS = Literal[
+    'WAICOLLE',
+    'WAIVENTURE',
+    'DEAD',
+    'RETIRED',
+]
+
+
 class WaicolleCollagePosition(StrEnum):
     DEFAULT = 'DEFAULT'
     LEFT_OF = 'LEFT_OF'
     RIGHT_OF = 'RIGHT_OF'
+
+
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
 
 
 class WaifuSelectByUserResultOwnerUser(BaseModel):
@@ -99,6 +117,8 @@ class WaifuSelectByUserResult(BaseModel):
     nanaed: bool
     original_owner: WaifuSelectByUserResultOriginalOwner | None
     owner: WaifuSelectByUserResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 
@@ -110,6 +130,7 @@ async def waifu_select_by_user(
     executor: AsyncIOExecutor,
     *,
     discord_id: str,
+    status: WAIFU_SELECT_BY_USER_STATUS,
     characters_ids_al: list[int] | None = None,
     level: int | None = None,
     locked: bool | None = None,
@@ -125,6 +146,7 @@ async def waifu_select_by_user(
     resp = await executor.query_json(  # pyright: ignore[reportUnknownMemberType]
         EDGEQL_QUERY,
         discord_id=discord_id,
+        status=status,
         characters_ids_al=characters_ids_al,
         level=level,
         locked=locked,

--- a/nanapi/database/waicolle/waifu_track_unlocked.py
+++ b/nanapi/database/waicolle/waifu_track_unlocked.py
@@ -76,6 +76,13 @@ class WaicolleCollagePosition(StrEnum):
     RIGHT_OF = 'RIGHT_OF'
 
 
+class WaicolleWaifuStatus(StrEnum):
+    DEAD = 'DEAD'
+    RETIRED = 'RETIRED'
+    WAICOLLE = 'WAICOLLE'
+    WAIVENTURE = 'WAIVENTURE'
+
+
 class WaifuTrackUnlockedResultOwnerUser(BaseModel):
     discord_id: str
 
@@ -116,6 +123,8 @@ class WaifuTrackUnlockedResult(BaseModel):
     nanaed: bool
     original_owner: WaifuTrackUnlockedResultOriginalOwner | None
     owner: WaifuTrackUnlockedResultOwner
+    season: str | None
+    status: WaicolleWaifuStatus | None
     timestamp: datetime
     trade_locked: bool
 

--- a/nanapi/routers/waicolle.py
+++ b/nanapi/routers/waicolle.py
@@ -107,7 +107,10 @@ from nanapi.database.waicolle.waifu_select_by_chara import (
     WaifuSelectByCharaResult,
     waifu_select_by_chara,
 )
-from nanapi.database.waicolle.waifu_select_by_user import waifu_select_by_user
+from nanapi.database.waicolle.waifu_select_by_user import (
+    WAIFU_SELECT_BY_USER_STATUS,
+    waifu_select_by_user,
+)
 from nanapi.database.waicolle.waifu_track_unlocked import waifu_track_unlocked
 from nanapi.database.waicolle.waifu_update_ascended_from import waifu_update_ascended_from
 from nanapi.database.waicolle.waifu_update_custom_image_name import (
@@ -441,7 +444,12 @@ async def get_player_track_reversed(
     """
     try:
         unlocked = await waifu_select_by_user(
-            edgedb, discord_id=discord_id, locked=False, trade_locked=False, blooded=False
+            edgedb,
+            discord_id=discord_id,
+            locked=False,
+            trade_locked=False,
+            blooded=False,
+            status='WAICOLLE',
         )
     except CardinalityViolationError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -646,7 +654,7 @@ async def get_player_collage(
                 (group.elements[0] for group in resp), key=lambda w: w.timestamp, reverse=True
             )
         else:
-            kwargs = dict(blooded=False)
+            kwargs: dict[str, Any] = dict(blooded=False)
             if _filter is CollageChoice.FULL:
                 pass
             elif _filter is CollageChoice.LOCKED:
@@ -710,6 +718,7 @@ async def get_player_media_album(
             discord_id=discord_id,
             characters_ids_al=[c.id_al for c in sorted_charas],
             blooded=False,
+            status='WAICOLLE',
         )
 
         url = await chara_album(list(sorted_charas), list(waifus), owned_only=bool(owned_only))
@@ -754,6 +763,7 @@ async def get_player_staff_album(
             discord_id=discord_id,
             characters_ids_al=[c.id_al for c in sorted_charas],
             blooded=False,
+            status='WAICOLLE',
         )
 
         url = await chara_album(list(sorted_charas), list(waifus), owned_only=bool(owned_only))
@@ -794,6 +804,7 @@ async def get_player_collection_album(
             discord_id=discord_id,
             characters_ids_al=[c.id_al for c in sorted_charas],
             blooded=False,
+            status='WAICOLLE',
         )
 
         url = await chara_album(list(sorted_charas), list(waifus), owned_only=bool(owned_only))
@@ -830,10 +841,12 @@ async def get_waifus(
     edged: int | None = None,
     ascendable: int | None = None,
     chara_id_al: int | None = None,
+    waifu_status: WAIFU_SELECT_BY_USER_STATUS = 'WAICOLLE',
     edgedb: AsyncIOClient = Depends(get_client_edgedb),
 ):
     """
     Get waifus with various filters:
+
     ids: List of waifu IDs
     discord_id: Owner or original owner (if as_og)
     level: Waifu level
@@ -847,6 +860,7 @@ async def get_waifus(
     exclude_custom_image: Exclude custom_images from the response (0 or None: no, 1: yes)
     edged: Whether waifu is close to a level upgrade (0 or None: ignore filter, 1: yes)
     ascendable: Whether waifu can level up (0 or None: ignore filter, 1: yes)
+    status: Status of waifu (Waicolle, Waiventure, dead)
     chara_id_al: Waifus matching a specific character ID.
     chara_id_al is exclusive and cannot be used with other filters.
     """
@@ -871,6 +885,7 @@ async def get_waifus(
         exclude_custom_image=(
             bool(exclude_custom_image) if exclude_custom_image is not None else None
         ),
+        waifu_status=waifu_status,
         edged=bool(edged) if edged is not None else None,
         ascendable=bool(ascendable) if ascendable is not None else None,
         chara_id_al=chara_id_al,
@@ -906,6 +921,7 @@ async def _search_waifus(
     ascended: bool | None = None,
     exclude_custom_image: bool | None = None,
     edged: bool | None = None,
+    waifu_status: WAIFU_SELECT_BY_USER_STATUS = 'WAICOLLE',
     ascendable: bool | None = None,
     chara_id_al: int | None = None,
 ):
@@ -939,6 +955,7 @@ async def _search_waifus(
                     as_og=as_og,
                     ascended=ascended,
                     exclude_custom_image=exclude_custom_image,
+                    status=waifu_status,
                 )
         except CardinalityViolationError as e:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -1050,6 +1067,7 @@ async def blood_expired_waifus(
                 trade_locked=False,
                 blooded=False,
                 nanaed=True,
+                status='WAICOLLE',
             )
             expired = [w for w in waifus if w.timestamp < datetime.now(tz=TZ) - timedelta(days=30)]
             return await waifu_bulk_update(tx, ids=[w.id for w in expired], blooded=True)


### PR DESCRIPTION
Had a note lying around with that to add, I implemented it so I can `rm` it.

RETIRED is badly defined and should probably be computed from “status == WAICOLLE + season set to any value” (I think “retired” heroes were meant to come back in the user’s waicolle collages/collections, but we should check).
Also there’s no endpoint to set the status/season in this commit it just adds the fields without breaking anything (hopefully).